### PR TITLE
feat: auto-acknowledge receipt with 👀 reaction

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface FeishuAccountConfig {
   appSecret: string;
   /** 可选的 workspace 路径 */
   workspace?: string;
+  /** 自动确认回执：收到消息时加 👀 reaction，回复后移除（默认 true） */
+  autoAcknowledge?: boolean;
 }
 
 export interface FeishuChannelConfig {
@@ -29,6 +31,8 @@ export interface ResolvedFeishuAccount {
   appSecret: string;
   workspace?: string;
   enabled?: boolean;
+  /** 自动确认回执（默认 true） */
+  autoAcknowledge?: boolean;
 }
 
 export interface FeishuMessage {


### PR DESCRIPTION
## Summary
收到消息时自动加 👀 reaction 表示 bot 正在处理，回复发送后自动移除。

## Changes
- **gateway.ts**: 消息接收后调用 addReaction 加 👀，缓存 reactionId
- **channel.ts**: 回复发送完毕后调用 removeReaction 移除 👀
- **types.ts**: 新增 autoAcknowledge 配置字段

## Configuration
默认开启。如需关闭，在 account 配置中设置：
```json
{ "autoAcknowledge": false }
```

## Notes
- 飞书 bot 不支持原生已读回执 API，使用 reaction 作为替代方案
- 5分钟自动清理防止内存泄漏
- TypeScript 编译通过，无错误

Closes #1